### PR TITLE
python version was slightly limited

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -78,7 +78,7 @@ install_requires =
     xarray
 setup_requires=
     setuptools_scm
-python_requires = >= 3.8, <=3.11
+python_requires = >= 3.8
 ################ Up until here
 
 [options.package_data]


### PR DESCRIPTION
removed `<=3.11` which caused issues in conda-forge testing